### PR TITLE
Pivot to Text Embedding transfer learning

### DIFF
--- a/notebooks/TL_text_embedding.ipynb
+++ b/notebooks/TL_text_embedding.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Transfer Learning on A Pre-Trained Text Embedding Transformer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, AutoModel\n",
+    "import torch\n",
+    "from torch.utils.data import Dataset, DataLoader\n",
+    "from torch import Tensor\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = \"thenlper/gte-base\" # This model is fairly small and is #22 on MTEB leaderboard\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "model = AutoModel.from_pretrained(MODEL_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CustomTextEmbeddingModel(torch.nn.Module):\n",
+    "    def __init__(self, original_model, output_dim):\n",
+    "        super(CustomTextEmbeddingModel, self).__init__()\n",
+    "        self.original_model = original_model\n",
+    "        # 768 is the embedding dims for the original gte-base model. adding another layer on the end to project to the output dim\n",
+    "        self.projection = torch.nn.Linear(768, output_dim)\n",
+    "\n",
+    "    def forward(self, input_ids, attention_mask=None):\n",
+    "        # Original model output\n",
+    "        outputs = self.original_model(input_ids=input_ids, attention_mask=attention_mask)\n",
+    "        pooled_output = self._average_pool(outputs.last_hidden_state, attention_mask)\n",
+    "        # Project to new output dim\n",
+    "        projected_output = self.projection(pooled_output)\n",
+    "        return projected_output\n",
+    "    \n",
+    "    # This function is from https://huggingface.co/thenlper/gte-base\n",
+    "    def _average_pool(self, last_hidden_states: Tensor, attention_mask: Tensor) -> Tensor:\n",
+    "        last_hidden = last_hidden_states.masked_fill(~attention_mask[..., None].bool(), 0.0)\n",
+    "        return last_hidden.sum(dim=1) / attention_mask.sum(dim=1)[..., None]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[-0.2958, -0.4906,  0.2907, -0.6942, -0.1876,  0.2642, -0.3741, -0.1587,\n",
+      "          0.1651,  0.3889],\n",
+      "        [-0.2686, -0.2305,  0.3190, -0.6691, -0.1300,  0.2702, -0.2727, -0.2254,\n",
+      "          0.2705,  0.3965]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A test to verify that the model is working. Outputs should just be meaningless tensors of size 10\n",
+    "test_model = CustomTextEmbeddingModel(model, 10)\n",
+    "\n",
+    "# Tokenize test inputs\n",
+    "test_inputs = [\"This is test sentence 1\", \"This is test sentence 2\"]\n",
+    "batch_dict = tokenizer(test_inputs, max_length=512, padding=True, truncation=True, return_tensors='pt')\n",
+    "\n",
+    "# Pass the tokenized inputs through your custom model\n",
+    "with torch.no_grad():\n",
+    "    embeddings = test_model(batch_dict['input_ids'], batch_dict['attention_mask'])\n",
+    "\n",
+    "#print(batch_dict)\n",
+    "print(embeddings)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Freeze Pre-Trained Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def freeze_pretrained_weights(model: nn.Module):\n",
+    "    '''\n",
+    "    Freezes the pretrained weights for an instance of the CustomTextEmbeddingModel class\n",
+    "    '''\n",
+    "    for param in model.original_model.parameters():\n",
+    "        param.requires_grad = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup a Dataset Class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TextDataset(Dataset):\n",
+    "    def __init__(self, texts, labels, tokenizer):\n",
+    "        self.texts = texts\n",
+    "        self.labels = labels\n",
+    "        self.tokenizer = tokenizer\n",
+    "    \n",
+    "    def __len__(self):\n",
+    "        return len(self.texts)\n",
+    "    \n",
+    "    def __getitem__(self, idx):\n",
+    "        encoded_text = self.tokenizer(self.texts[idx], return_tensors='pt', padding='max_length', truncation=True, max_length=512)\n",
+    "        label = torch.tensor(self.labels[idx], dtype=torch.long)\n",
+    "        return encoded_text, label\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example usage of the TextDataset class\n",
+    "\n",
+    "# Example text, labels, and tokenizer\n",
+    "    # Image captions\n",
+    "texts = [\"Caption for image 1\", \"Caption for image 2\", \"Caption for image 3\"]\n",
+    "    # The labels are the image embeddings from the image embedding model.\n",
+    "labels = [Tensor([1,2,3,4,5,6,7,8,9,0]), Tensor([1,2,3,4,5,6,7,8,9,0]), Tensor([1,2,3,4,5,6,7,8,9,0])]\n",
+    "    # This is the tokenizer for our base pretrained text embedding model: gte-base\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "\n",
+    "\n",
+    "dataset = TextDataset(texts, labels, tokenizer)\n",
+    "dataloader = DataLoader(dataset, batch_size=2, shuffle=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ click==8.1.3
 # Data manipulation and analysis
 numpy==1.26.4
 pandas==2.1.0
+transformers==4.38.2
 
 # CUDA
 #torch==2.2.1+cu118


### PR DESCRIPTION
I created a new notebook that sets up some valuable functions and classes for transfer learning on the `thenlper/gte-base` text embedding model. 

I realized that creating an image embedding model to align with a pre-existing text embedding model was probably too much of a CV focused project instead of NLP. So I think we should flip it and instead finetune/transfer learn a pretrained text embedding model (gte-base) to produce embeddings in the same latent space as a pretrained image embedding model (some ViT).